### PR TITLE
fix(DataTriggerBehavior): Add workaround for Load/Unload sequence

### DIFF
--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/DataTriggerBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactions/Core/DataTriggerBehavior.cs
@@ -199,17 +199,23 @@ namespace Microsoft.Xaml.Interactions.Core
         private static void OnValueChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
         {
             DataTriggerBehavior dataTriggerBehavior = (DataTriggerBehavior)dependencyObject;
-            if (dataTriggerBehavior.AssociatedObject == null)
+            var behavior2 = dependencyObject as IBehavior2;
+
+            if (dataTriggerBehavior.AssociatedObject == null && behavior2?.AssociatedObjectWeak == null)
             {
                 return;
             }
+
+            // UNO TODO: https://github.com/unoplatform/uno/issues/3519
+            // The AssociatedObject is set too late, missing binding updates
+            var associatedObject = dataTriggerBehavior.AssociatedObject ?? behavior2?.AssociatedObjectWeak;
 
             DataBindingHelper.RefreshDataBindingsOnActions(dataTriggerBehavior.Actions);
 
             // Some value has changed--either the binding value, reference value, or the comparison condition. Re-evaluate the equation.
             if (DataTriggerBehavior.Compare(dataTriggerBehavior.Binding, dataTriggerBehavior.ComparisonCondition, dataTriggerBehavior.Value))
             {
-                Interaction.ExecuteActions(dataTriggerBehavior.AssociatedObject, dataTriggerBehavior.Actions, args);
+                Interaction.ExecuteActions(associatedObject, dataTriggerBehavior.Actions, args);
             }
         }
     }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Behavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Behavior.cs
@@ -12,11 +12,33 @@ namespace Microsoft.Xaml.Interactivity
     /// A base class for behaviors, implementing the basic plumbing of IBehavior
     /// </summary>
     public abstract partial class Behavior : DependencyObject, IBehavior
+#if HAS_UNO
+        , IBehavior2
+#endif
     {
         /// <summary>
         /// Gets the <see cref="Windows.UI.Xaml.DependencyObject"/> to which the behavior is attached.
         /// </summary>
         public DependencyObject AssociatedObject { get; private set; }
+
+#if HAS_UNO
+        private WeakReference _associatedObjectWeak;
+
+        DependencyObject IBehavior2.AssociatedObjectWeak {
+            get => _associatedObjectWeak?.Target as DependencyObject;
+            set
+            {
+                if (value != null)
+                {
+                    _associatedObjectWeak = new WeakReference(value);
+                }
+                else
+                {
+                    _associatedObjectWeak = null;
+                }
+            }
+        }
+#endif
 
         /// <summary>
         /// Attaches the behavior to the specified <see cref="Windows.UI.Xaml.DependencyObject"/>.
@@ -44,6 +66,10 @@ namespace Microsoft.Xaml.Interactivity
             if (associatedObject == null) throw new ArgumentNullException(nameof(associatedObject));
 
             AssociatedObject = associatedObject;
+
+#if HAS_UNO
+            (this as IBehavior2).AssociatedObjectWeak = associatedObject;
+#endif
             OnAttached();
         }
 

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/BehaviorCollection.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/BehaviorCollection.cs
@@ -34,6 +34,31 @@ namespace Microsoft.Xaml.Interactivity
             private set;
         }
 
+
+#if HAS_UNO
+        private WeakReference _associatedObjectWeak;
+
+        internal DependencyObject AssociatedObjectWeak {
+            get => _associatedObjectWeak?.Target as DependencyObject;
+            set {
+                if (value != null)
+                {
+                    _associatedObjectWeak = new WeakReference(value);
+                }
+                else
+                {
+                    _associatedObjectWeak = null;
+                }
+
+                foreach (DependencyObject item in this)
+                {
+                    IBehavior2 behavior = (IBehavior2)item;
+                    behavior.AssociatedObjectWeak = value;
+                }
+            }
+        }
+#endif
+
         /// <summary>
         /// Attaches the collection of behaviors to the specified <see cref="Windows.UI.Xaml.DependencyObject"/>.
         /// </summary>
@@ -167,6 +192,13 @@ namespace Microsoft.Xaml.Interactivity
             {
                 behavior.Attach(this.AssociatedObject);
             }
+
+#if HAS_UNO
+            if(item is IBehavior2 behavior2)
+            {
+                behavior2.AssociatedObjectWeak = AssociatedObjectWeak;
+            }
+#endif
 
             return behavior;
         }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/IBehavior.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/IBehavior.cs
@@ -4,28 +4,37 @@ namespace Microsoft.Xaml.Interactivity
 {
     using Windows.UI.Xaml;
 
-	/// <summary>
-	/// Interface implemented by all custom behaviors.
-	/// </summary>
-	public interface IBehavior
+    /// <summary>
+    /// Interface implemented by all custom behaviors.
+    /// </summary>
+    public interface IBehavior
     {
-		/// <summary>
-		/// Gets the <see cref="Windows.UI.Xaml.DependencyObject"/> to which the <seealso cref="IBehavior"/> is attached.
-		/// </summary>
-		DependencyObject AssociatedObject
-        {
+        /// <summary>
+        /// Gets the <see cref="Windows.UI.Xaml.DependencyObject"/> to which the <seealso cref="IBehavior"/> is attached.
+        /// </summary>
+        DependencyObject AssociatedObject {
             get;
         }
 
-		/// <summary>
-		/// Attaches to the specified object.
-		/// </summary>
-		/// <param name="associatedObject">The <see cref="Windows.UI.Xaml.DependencyObject"/> to which the <seealso cref="IBehavior"/> will be attached.</param>
-		void Attach(DependencyObject associatedObject);
+        /// <summary>
+        /// Attaches to the specified object.
+        /// </summary>
+        /// <param name="associatedObject">The <see cref="Windows.UI.Xaml.DependencyObject"/> to which the <seealso cref="IBehavior"/> will be attached.</param>
+        void Attach(DependencyObject associatedObject);
 
         /// <summary>
         /// Detaches this instance from its associated object.
         /// </summary>
         void Detach();
+    }
+
+    internal interface IBehavior2
+    {
+        /// <summary>
+        /// Gets the <see cref="Windows.UI.Xaml.DependencyObject"/> to which the <seealso cref="IBehavior"/> is attached.
+        /// </summary>
+        DependencyObject AssociatedObjectWeak {
+            get; set;
+        }
     }
 }

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Interaction.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Interaction.cs
@@ -49,6 +49,10 @@ namespace Microsoft.Xaml.Interactivity
 
                 if (frameworkElement != null)
                 {
+#if HAS_UNO
+                    behaviorCollection.AssociatedObjectWeak = frameworkElement;
+#endif
+
                     frameworkElement.Loaded -= FrameworkElement_Loaded;
                     frameworkElement.Loaded += FrameworkElement_Loaded;
                     frameworkElement.Unloaded -= FrameworkElement_Unloaded;

--- a/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Properties/AssemblyInfo.cs
+++ b/src/BehaviorsSDKManaged/Microsoft.Xaml.Interactivity/Properties/AssemblyInfo.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
+[assembly: InternalsVisibleTo("Microsoft.Xaml.Interactions")]


### PR DESCRIPTION
Adjusts the behavior `DataTriggerBehavior` of because of https://github.com/unoplatform/uno/issues/3519.

Fixes https://github.com/unoplatform/uno/issues/5583